### PR TITLE
feat: Added parameter to ignore insignificant commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Options:
   -d|--dry-run                         Skip changing versions in projects, changelog generation and git commit
   --skip-dirty                         Skip git dirty check
   -r|--release-as <VERSION>            Specify the release version manually
-  --silent                             Supress output to console
+  --silent                             Suppress output to console
+  -i|--ignore-insignificant-commits    Dont do anything when only insignificant commits (anything other then fix, feat, or BREAKING) are found
 ```
 
 ## Supported commit types
@@ -134,5 +135,5 @@ versionize detected a breaking change since the commit note `BREAKING CHANGE` wa
 ## Roadmap
 
 * Pre Releases to allow creating beta.1, beta.2 versions
-* ~~--silent command line switch to supress commandline output~~
+* ~~--silent command line switch to suppress commandline output~~
 * --should-version command line switch to test if a new version should be created based on commits and return a non zero exit code if no new version should be released

--- a/Versionize.Tests/WorkingCopyTests.cs
+++ b/Versionize.Tests/WorkingCopyTests.cs
@@ -1,13 +1,26 @@
-﻿using System;
+﻿using System.Threading;
+using System;
 using System.IO;
 using Xunit;
 using Versionize.Tests.TestSupport;
 using Versionize.CommandLine;
+using LibGit2Sharp;
+using System.Xml;
+using System.Linq;
 
 namespace Versionize.Tests
 {
     public class WorkingCopyTests
     {
+        // Thanks @dtb https://stackoverflow.com/a/1344242
+        private static Random _random = new Random();
+        private static string _RandomString(int length)
+        {
+            const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+            return new string(Enumerable.Repeat(chars, length)
+              .Select(s => s[_random.Next(s.Length)]).ToArray());
+        }
+
         public WorkingCopyTests()
         {
             CommandLineUI.Platform = new TestPlatformAbstractions();
@@ -45,6 +58,95 @@ namespace Versionize.Tests
             workingCopy.Versionize(dryrun: true, skipDirtyCheck: true);
 
             // TODO: Assert messages
+        }
+
+        [Fact]
+        public void ShouldIgnoreInsignificantCommits()
+        {
+            // Set directory and filenames
+            var random = new Random();
+            var tempDir = $"{Path.GetTempPath()}{_RandomString(10)}";
+            var tempFile = $"{tempDir}/{_RandomString(10)}.txt";
+            var csProjFile = $"{tempDir}/{Path.GetFileName(tempDir)}.csproj";
+            Directory.CreateDirectory(tempDir);
+            Repository.Init(tempDir);
+
+            // Initialize git repo
+            using (var repo = new Repository(tempDir))
+            {
+
+                // Create .net project
+                System.Diagnostics.Process.Start("dotnet", $"new console -o {tempDir}").WaitForExit();
+
+                // Add version string to csproj
+                XmlDocument doc = new XmlDocument();
+                doc.PreserveWhitespace = true;
+
+                try
+                {
+                    doc.Load(csProjFile);
+                }
+                catch (Exception)
+                {
+                    throw;
+                }
+
+                var projectNode = doc.SelectSingleNode("/Project/PropertyGroup");
+                var versionNode = doc.CreateNode("element", "Version", "");
+                versionNode.InnerText = "0.0.0";
+                projectNode.AppendChild(versionNode);
+                using (var tw = new XmlTextWriter(csProjFile, null))
+                {
+                    doc.Save(tw);
+                }
+
+                // Create author
+                var author = new Signature("Gitty McGitface", "noreply@git.com", DateTime.Now);
+
+                // Create and commit testfile
+                File.WriteAllText(tempFile, "First line of text");
+                Commands.Stage(repo, "*");
+                repo.Commit("feat: Initial commit", author, author);
+
+                // Run versionize
+                var workingCopy = WorkingCopy.Discover(tempDir);
+                workingCopy.Versionize();
+
+                // Add insignificant change
+                using (var sw = File.AppendText(tempFile))
+                {
+                    sw.WriteLine("This is another line of text");
+                }
+                Commands.Stage(repo, "*");
+                author = new Signature("Gitty McGitface", "noreply@git.com", DateTime.Now);
+                repo.Commit("chore: Added line of text", author, author);
+
+                // Get last commit
+                var lastCommit = repo.Head.Tip;
+
+                // Run versionize, ignoring insignificant commits
+                try
+                {
+                    workingCopy.Versionize(ignoreInsignificant: true);
+                }
+                catch (CommandLineExitException ex)
+                {
+                    Assert.Equal(0, ex.ExitCode);
+                }
+                Assert.Equal(lastCommit, repo.Head.Tip);
+            }
+
+            // Cleanup
+            // Need to cleanup readonly attributes first...
+            foreach (var file in Directory.GetFiles(tempDir, "*", SearchOption.AllDirectories))
+            {
+                var attribs = File.GetAttributes(file);
+                if (attribs.HasFlag(FileAttributes.ReadOnly))
+                {
+                    File.SetAttributes(file, attribs & ~FileAttributes.ReadOnly);
+                }
+            }
+            Directory.Delete(tempDir, true);
         }
     }
 }

--- a/Versionize/Program.cs
+++ b/Versionize/Program.cs
@@ -23,21 +23,23 @@ namespace Versionize
             var optionDryRun = app.Option("-d|--dry-run", "Skip changing versions in projects, changelog generation and git commit", CommandOptionType.NoValue);
             var optionSkipDirty = app.Option("--skip-dirty", "Skip git dirty check", CommandOptionType.NoValue);
             var optionReleaseAs = app.Option("-r|--release-as <VERSION>", "Specify the release version manually", CommandOptionType.SingleValue);
-            var optionSilent = app.Option("--silent", "Supress output to console", CommandOptionType.NoValue);
+            var optionSilent = app.Option("--silent", "Suppress output to console", CommandOptionType.NoValue);
 
             var optionSkipCommit = app.Option("--skip-commit", "Skip commit and git tag after updating changelog and incrementing the version", CommandOptionType.NoValue);
+            var optionIgnoreInsignificant = app.Option("-i|--ignore-insignificant-commits", "Do not bump the version if no significant commits (fix, feat or BREAKING) are found", CommandOptionType.NoValue);
 
             app.OnExecute(() =>
             {
-                CommandLineUI.Verbosity = optionSilent.HasValue()?LogLevel.Silent:LogLevel.All;
+                CommandLineUI.Verbosity = optionSilent.HasValue() ? LogLevel.Silent : LogLevel.All;
 
                 WorkingCopy
                     .Discover(optionWorkingDirectory.Value() ?? Directory.GetCurrentDirectory())
                     .Versionize(
-                        dryrun: optionDryRun.HasValue(), 
-                        skipDirtyCheck: optionSkipDirty.HasValue(), 
-                        skipCommit: optionSkipCommit.HasValue(), 
-                        releaseVersion: optionReleaseAs.Value());
+                        dryrun: optionDryRun.HasValue(),
+                        skipDirtyCheck: optionSkipDirty.HasValue(),
+                        skipCommit: optionSkipCommit.HasValue(),
+                        releaseVersion: optionReleaseAs.Value(),
+                        ignoreInsignificant: optionIgnoreInsignificant.HasValue());
 
                 return 0;
             });

--- a/Versionize/VersionIncrement.cs
+++ b/Versionize/VersionIncrement.cs
@@ -13,7 +13,7 @@ namespace Versionize
             _versionImpact = versionImpact;
         }
 
-        public Version NextVersion(Version version)
+        public Version NextVersion(Version version, bool ignoreInsignificant)
         {
             switch (_versionImpact)
             {
@@ -24,7 +24,8 @@ namespace Versionize
                 case VersionImpact.major:
                     return new Version(version.Major + 1, 0, 0);
                 case VersionImpact.none:
-                    return new Version(version.Major, version.Minor, version.Build + 1);
+                    var buildVersion = ignoreInsignificant ? version.Build : version.Build + 1;
+                    return new Version(version.Major, version.Minor, buildVersion);
                 default:
                     throw new InvalidOperationException($"Version impact of {_versionImpact} cannot be handled");
             }

--- a/Versionize/WorkingCopy.cs
+++ b/Versionize/WorkingCopy.cs
@@ -16,10 +16,11 @@ namespace Versionize
         }
 
         public void Versionize(
-            bool dryrun = false, 
+            bool dryrun = false,
             bool skipDirtyCheck = false,
             bool skipCommit = false,
-            string releaseVersion = null)
+            string releaseVersion = null,
+            bool ignoreInsignificant = false)
         {
             var workingDirectory = _directory.FullName;
 
@@ -58,7 +59,12 @@ namespace Versionize
 
                 var versionIncrement = VersionIncrementStrategy.CreateFrom(conventionalCommits);
 
-                var nextVersion = versionTag == null ? projects.Version : versionIncrement.NextVersion(projects.Version);
+                var nextVersion = versionTag == null ? projects.Version : versionIncrement.NextVersion(projects.Version, ignoreInsignificant);
+
+                if (ignoreInsignificant && nextVersion == projects.Version)
+                {
+                    Exit($"Version was not affected by commits since last release ({projects.Version}), since you specified to ignore insignificant changes, no action will be performed.", 0);
+                }
 
                 if (!String.IsNullOrWhiteSpace(releaseVersion))
                 {


### PR DESCRIPTION
This parameter allows for users to specify that Versionize should ignore insignificant commits.
Insignificant commits are any non- `feat`, `fix` or `BREAKING` commit

fixes #7