### PR TITLE
fix: typo in method name

### DIFF
--- a/Versionize/RepositoryExtensions.cs
+++ b/Versionize/RepositoryExtensions.cs
@@ -12,7 +12,7 @@ namespace Versionize
             return repository.Tags.SingleOrDefault(t => t.FriendlyName == $"v{version}");
         }
 
-        public static List<Commit> GteCommitsSinceLastVersion(this Repository repository, Tag versionTag)
+        public static List<Commit> GetCommitsSinceLastVersion(this Repository repository, Tag versionTag)
         {
             if (versionTag == null)
             {

--- a/Versionize/WorkingCopy.cs
+++ b/Versionize/WorkingCopy.cs
@@ -52,7 +52,7 @@ namespace Versionize
                 }
 
                 var versionTag = repo.SelectVersionTag(projects.Version);
-                var commitsInVersion = repo.GteCommitsSinceLastVersion(versionTag);
+                var commitsInVersion = repo.GetCommitsSinceLastVersion(versionTag);
 
                 var commitParser = new ConventionalCommitParser();
                 var conventionalCommits = commitParser.Parse(commitsInVersion);


### PR DESCRIPTION
Fixed typo in method name.
Changed from `GteCommitsSinceLastVersion` to `GetCommitsSinceLastVersion`