### PR TITLE
feat: add release commit message suffix option

### DIFF
--- a/Versionize.Tests/WorkingCopyTests.cs
+++ b/Versionize.Tests/WorkingCopyTests.cs
@@ -147,6 +147,28 @@ namespace Versionize.Tests
             lastCommit.ShouldBe(_testSetup.Repository.Head.Tip);
         }
 
+        [Fact]
+        public void ShouldAddSuffixToReleaseCommitMessage()
+        {
+            TempCsProject.Create(_testSetup.WorkingDirectory);
+
+            var workingFilePath = Path.Join(_testSetup.WorkingDirectory, "hello.txt");
+
+            // Create and commit a test file
+            File.WriteAllText(workingFilePath, "First line of text");
+            CommitAll(_testSetup.Repository);
+
+            // Run versionize
+            var workingCopy = WorkingCopy.Discover(_testSetup.WorkingDirectory);
+            var suffix = "[skip ci]";
+            workingCopy.Versionize(releaseCommitMessageSuffix: suffix);
+
+            // Get last commit
+            var lastCommit = _testSetup.Repository.Head.Tip;
+
+            lastCommit.Message.ShouldContain(suffix);
+        }
+
         public void Dispose()
         {
             _testSetup.Dispose();

--- a/Versionize/Program.cs
+++ b/Versionize/Program.cs
@@ -25,7 +25,7 @@ namespace Versionize
             var optionSkipCommit = app.Option("--skip-commit", "Skip commit and git tag after updating changelog and incrementing the version", CommandOptionType.NoValue);
             var optionIgnoreInsignificant = app.Option("-i|--ignore-insignificant-commits", "Do not bump the version if no significant commits (fix, feat or BREAKING) are found", CommandOptionType.NoValue);
             var optionIncludeAllCommitsInChangelog = app.Option("--changelog-all", "Include all commits in the changelog not just fix, feat and breaking changes", CommandOptionType.NoValue);
-            var optionReleaseCommitMessageSuffix = app.Option("--commit-suffix", "Suffix to be added to the end of the release commit message (e.g. [skip ci]", CommandOptionType.SingleValue);
+            var optionReleaseCommitMessageSuffix = app.Option("--commit-suffix", "Suffix to be added to the end of the release commit message (e.g. [skip ci])", CommandOptionType.SingleValue);
 
             app.OnExecute(() =>
             {

--- a/Versionize/Program.cs
+++ b/Versionize/Program.cs
@@ -1,7 +1,4 @@
-using System;
-using System.ComponentModel.DataAnnotations;
 using System.IO;
-using System.Reflection;
 using McMaster.Extensions.CommandLineUtils;
 using Versionize.CommandLine;
 

--- a/Versionize/Program.cs
+++ b/Versionize/Program.cs
@@ -25,6 +25,7 @@ namespace Versionize
             var optionSkipCommit = app.Option("--skip-commit", "Skip commit and git tag after updating changelog and incrementing the version", CommandOptionType.NoValue);
             var optionIgnoreInsignificant = app.Option("-i|--ignore-insignificant-commits", "Do not bump the version if no significant commits (fix, feat or BREAKING) are found", CommandOptionType.NoValue);
             var optionIncludeAllCommitsInChangelog = app.Option("--changelog-all", "Include all commits in the changelog not just fix, feat and breaking changes", CommandOptionType.NoValue);
+            var optionReleaseCommitMessageSuffix = app.Option("--commit-suffix", "Suffix to be added to the end of the release commit message (e.g. [skip ci]", CommandOptionType.SingleValue);
 
             app.OnExecute(() =>
             {
@@ -38,7 +39,8 @@ namespace Versionize
                         skipCommit: optionSkipCommit.HasValue(),
                         releaseVersion: optionReleaseAs.Value(),
                         ignoreInsignificant: optionIgnoreInsignificant.HasValue(),
-                        includeAllCommitsInChangelog: optionIncludeAllCommitsInChangelog.HasValue()
+                        includeAllCommitsInChangelog: optionIncludeAllCommitsInChangelog.HasValue(),
+                        releaseCommitMessageSuffix: optionReleaseCommitMessageSuffix.Value()
                     );
 
                 return 0;

--- a/Versionize/WorkingCopy.cs
+++ b/Versionize/WorkingCopy.cs
@@ -19,8 +19,9 @@ namespace Versionize
             bool skipDirtyCheck = false,
             bool skipCommit = false,
             string releaseVersion = null,
-            bool ignoreInsignificant = false, 
-            bool includeAllCommitsInChangelog = false)
+            bool ignoreInsignificant = false,
+            bool includeAllCommitsInChangelog = false,
+            string releaseCommitMessageSuffix = null)
         {
             var workingDirectory = _directory.FullName;
 
@@ -119,7 +120,7 @@ namespace Versionize
                     var committer = author;
 
                     // TODO: Check if tag exists before commit
-                    var releaseCommitMessage = $"chore(release): {nextVersion}";
+                    var releaseCommitMessage = $"chore(release): {nextVersion} {releaseCommitMessageSuffix}".TrimEnd();
                     var versionCommit = repo.Commit(releaseCommitMessage, author, committer);
                     Step($"committed changes in projects and CHANGELOG.md");
 


### PR DESCRIPTION
Adds an `--commit-suffix` option to be able to add a suffix to the release commit message created when running `versionize`.

This is useful when running `versionize` in a CI/CD pipeline that triggers on each push to a target branch; usually `main` or `master`. 
By adding the suffix `[skip ci]` to the release commit message we prevent the pipeline from re-triggering when pushing back the CHANGELOG.md, tag and updated `.csproj`-files.

Sample usage
```
// Running
versionize --commit-suffix [skip ci]

// would result in following commit message
chore(release): 1.2.0 [skip ci]
```

