### PR TITLE
fix: invalid url exception

### DIFF
--- a/Versionize.Tests/Changelog/AzureLinkBuilderTests.cs
+++ b/Versionize.Tests/Changelog/AzureLinkBuilderTests.cs
@@ -10,7 +10,7 @@ namespace Versionize.Changelog.Tests
     public class AzureLinkBuilderTests
     {
         [Fact]
-        public void ShouldIfUrlIsNoRecognizedSshOrHttpsUrl()
+        public void ShouldThrowIfUrlIsNoRecognizedSshOrHttpsUrl()
         {
             Should.Throw<InvalidOperationException>(() => new AzureLinkBuilder("azure.com"));
         }
@@ -80,15 +80,21 @@ namespace Versionize.Changelog.Tests
         }
 
         [Fact]
-        public void ShouldThrowIfSSHUrlDoesNotEndWithGit()
+        public void ShouldCreateAnAzureUrlBuilderForSSHPushUrlsEvenWithoutGitSuffix()
         {
-            Should.Throw<InvalidOperationException>(() => new AzureLinkBuilder("git@ssh.dev.azure.com:v3/dosse/DosSE.ERP.Cloud/ERP"));
+            var repo = SetupRepositoryWithRemote("origin", "git@ssh.dev.azure.com:v3/dosse/DosSE.ERP.Cloud/ERP");
+            var linkBuilder = LinkBuilderFactory.CreateFor(repo);
+
+            linkBuilder.ShouldBeAssignableTo<AzureLinkBuilder>();
         }
 
         [Fact]
-        public void ShouldThrowIfHTTPSUrlDoesNotEndWithGit()
+        public void ShouldCreateAnAzureUrlBuilderForHTTPSPushUrlsEvenWithoutGitSuffix()
         {
-            Should.Throw<InvalidOperationException>(() => new AzureLinkBuilder("https://dosse@dev.azure.com/dosse/DosSE.ERP.Cloud/_git/ERP"));
+            var repo = SetupRepositoryWithRemote("origin", "https://dosse@dev.azure.com/dosse/DosSE.ERP.Cloud/_git/ERP");
+            var linkBuilder = LinkBuilderFactory.CreateFor(repo);
+
+            linkBuilder.ShouldBeAssignableTo<AzureLinkBuilder>();
         }
 
         private static Repository SetupRepositoryWithRemote(string remoteName, string pushUrl)

--- a/Versionize.Tests/Changelog/GithubLinkBuilderTests.cs
+++ b/Versionize.Tests/Changelog/GithubLinkBuilderTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using LibGit2Sharp;
 using Shouldly;
@@ -10,7 +10,7 @@ namespace Versionize.Changelog.Tests
     public class GithubLinkBuilderTests
     {
         [Fact]
-        public void ShouldIfUrlIsNoRecognizedSshOrHttpsUrl()
+        public void ShouldThrowIfUrlIsNoRecognizedSshOrHttpsUrl()
         {
             Should.Throw<InvalidOperationException>(() => new GithubLinkBuilder("github.com"));
         }
@@ -52,15 +52,21 @@ namespace Versionize.Changelog.Tests
         }
 
         [Fact]
-        public void ShouldThrowIfSSHUrlDoesNotEndWithGit()
+        public void ShouldCreateAGithubUrlBuilderForSSHPushUrlsEvenWithoutGitSuffix()
         {
-            Should.Throw<InvalidOperationException>(() => new GithubLinkBuilder("git@github.com:saintedlama/versionize"));
+            var repo = SetupRepositoryWithRemote("origin", "git@github.com:saintedlama/versionize");
+            var linkBuilder = LinkBuilderFactory.CreateFor(repo);
+
+            linkBuilder.ShouldBeAssignableTo<GithubLinkBuilder>();
         }
 
         [Fact]
-        public void ShouldThrowIfHTTPSUrlDoesNotEndWithGit()
+        public void ShouldCreateAGithubUrlBuilderForHTTPSPushUrlsEvenWithoutGitSuffix()
         {
-            Should.Throw<InvalidOperationException>(() => new GithubLinkBuilder("https://github.com/saintedlama/versionize"));
+            var repo = SetupRepositoryWithRemote("origin", "https://github.com/saintedlama/versionize");
+            var linkBuilder = LinkBuilderFactory.CreateFor(repo);
+
+            linkBuilder.ShouldBeAssignableTo<GithubLinkBuilder>();
         }
 
         private static Repository SetupRepositoryWithRemote(string remoteName, string pushUrl)

--- a/Versionize/Changelog/AzureLinkBuilder.cs
+++ b/Versionize/Changelog/AzureLinkBuilder.cs
@@ -13,7 +13,7 @@ namespace Versionize.Changelog
         {
             if (pushUrl.StartsWith("git@ssh.dev.azure.com:"))
             {
-                var httpsPattern = new Regex("^git@ssh.dev.azure.com:(?<organization>.*?)/(?<repository>.*?)\\.git$");
+                var httpsPattern = new Regex("^git@ssh.dev.azure.com:(?<organization>.*?)/(?<repository>.*?)(?:\\.git)?$");
                 var matches = httpsPattern.Match(pushUrl);
 
                 if (!matches.Success)
@@ -26,7 +26,7 @@ namespace Versionize.Changelog
             }
             else if (pushUrl.StartsWith("https://") && pushUrl.Contains("@dev.azure.com/"))
             {
-                var httpsPattern = new Regex("^https://(?<organization>.*?)@dev.azure.com/(?<organization>.*?)/(?<repository>.*?)\\.git$");
+                var httpsPattern = new Regex("^https://(?<organization>.*?)@dev.azure.com/(?<organization>.*?)/(?<repository>.*?)(?:\\.git)?$");
                 var matches = httpsPattern.Match(pushUrl);
 
                 if (!matches.Success)

--- a/Versionize/Changelog/GithubLinkBuilder.cs
+++ b/Versionize/Changelog/GithubLinkBuilder.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text.RegularExpressions;
 using Version = NuGet.Versioning.SemanticVersion;
 
@@ -13,7 +13,7 @@ namespace Versionize.Changelog
         {
             if (pushUrl.StartsWith("git@github.com:"))
             {
-                var httpsPattern = new Regex("^git@github.com:(?<organization>.*?)/(?<repository>.*?)\\.git$");
+                var httpsPattern = new Regex("^git@github.com:(?<organization>.*?)/(?<repository>.*?)(?:\\.git)?$");
                 var matches = httpsPattern.Match(pushUrl);
 
                 if (!matches.Success)
@@ -26,7 +26,7 @@ namespace Versionize.Changelog
             }
             else if (pushUrl.StartsWith("https://github.com/"))
             {
-                var httpsPattern = new Regex("^https://github.com/(?<organization>.*?)/(?<repository>.*?)\\.git$");
+                var httpsPattern = new Regex("^https://github.com/(?<organization>.*?)/(?<repository>.*?)(?:\\.git)?$");
                 var matches = httpsPattern.Match(pushUrl);
 
                 if (!matches.Success)


### PR DESCRIPTION
Occurs when .git suffix is not included.
It's just a naming convention, so it's not required.

Fixes #30
Fixes #34