### PR TITLE
feat: support changelog customization options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Versionize
+﻿# Versionize
 
 [![Coverage Status](https://coveralls.io/repos/saintedlama/versionize/badge.svg?branch=)](https://coveralls.io/r/saintedlama/versionize?branch=master)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
@@ -138,6 +138,36 @@ versionize detected a breaking change since the commit note `BREAKING CHANGE` wa
 You can configure `versionize` either by creating a `.versionize` JSON file the working directory.
 
 Any of the command line parameters accepted by `versionized` can be provided via configuration file leaving out any `-`. For example `skip-dirty` can be provided as `skipDirty` in the configuration file.
+
+Changelog customization can only be done via a `.versionize` file. The following is an example configuration:
+
+```json
+{
+  "changelogAll": true,
+  "changelog": {
+    "header": "My Changelog",
+    "sections": [
+      {
+        "type": "feat",
+        "section": "✨ Features",
+        "hidden": false
+      },
+      {
+        "type": "fix",
+        "section": "🐛 Bug Fixes",
+        "hidden": true
+      },
+      {
+        "type": "perf",
+        "section": "🚀 Performance",
+        "hidden": false
+      }
+    ]
+  }
+}
+```
+
+Because `changelogAll` is true and the _fix_ section is hidden, fix commits will appear in the a section titled "Other".
 
 ## Developing
 

--- a/Versionize.Tests/Changelog/ChangelogBuilderTests.cs
+++ b/Versionize.Tests/Changelog/ChangelogBuilderTests.cs
@@ -193,6 +193,28 @@ namespace Versionize.Changelog.Tests
         }
 
         [Fact]
+        public void ShouldUseCustomHeaderWhenSpecified()
+        {
+            var plainLinkBuilder = new PlainLinkBuilder();
+            var changelog = ChangelogBuilder.CreateForPath(_testDirectory);
+            changelog.Write(
+                new Version(1, 1, 0),
+                new DateTimeOffset(),
+                plainLinkBuilder,
+                new List<ConventionalCommit>
+                {
+                    ConventionalCommitParser.Parse(new TestCommit("a360d6a307909c6e571b29d4a329fd786c5d4543", "fix: a fix")),
+                },
+                ChangelogOptions.Default with
+                {
+                    Header = "My custom changelog",
+                });
+
+            var changelogContents = File.ReadAllText(changelog.FilePath);
+            changelogContents.ShouldStartWith("My custom changelog", Case.Sensitive);
+        }
+
+        [Fact]
         public void ShouldAppendAtEndIfChangelogContainsExtraInformation()
         {
             File.WriteAllText(Path.Combine(_testDirectory, "CHANGELOG.md"), "# Should be kept by versionize\n\nSome information about the changelog");

--- a/Versionize.Tests/Changelog/ChangelogBuilderTests.cs
+++ b/Versionize.Tests/Changelog/ChangelogBuilderTests.cs
@@ -23,7 +23,12 @@ namespace Versionize.Changelog.Tests
         {
             var plainLinkBuilder = new PlainLinkBuilder();
             var changelog = ChangelogBuilder.CreateForPath(_testDirectory);
-            changelog.Write(new Version(1, 1, 0), new DateTimeOffset(), plainLinkBuilder, new List<ConventionalCommit>());
+            changelog.Write(
+                new Version(1, 1, 0),
+                new DateTimeOffset(),
+                plainLinkBuilder,
+                new List<ConventionalCommit>(),
+                ChangelogOptions.Default);
 
             var wasChangelogWritten = File.Exists(Path.Join(_testDirectory, "CHANGELOG.md"));
             Assert.True(wasChangelogWritten);
@@ -34,10 +39,15 @@ namespace Versionize.Changelog.Tests
         {
             var plainLinkBuilder = new PlainLinkBuilder();
             var changelog = ChangelogBuilder.CreateForPath(_testDirectory);
-            changelog.Write(new Version(1, 1, 0), new DateTimeOffset(), plainLinkBuilder, new List<ConventionalCommit>
-            {
-                ConventionalCommitParser.Parse(new TestCommit("a360d6a307909c6e571b29d4a329fd786c5d4543", "fix: a fix")),
-            });
+            changelog.Write(
+                new Version(1, 1, 0),
+                new DateTimeOffset(),
+                plainLinkBuilder,
+                new List<ConventionalCommit>
+                {
+                    ConventionalCommitParser.Parse(new TestCommit("a360d6a307909c6e571b29d4a329fd786c5d4543", "fix: a fix")),
+                },
+                ChangelogOptions.Default);
 
             var contents = File.ReadAllText(Path.Join(_testDirectory, "CHANGELOG.md"));
             contents.ShouldNotContain("\\n");
@@ -48,18 +58,138 @@ namespace Versionize.Changelog.Tests
         {
             var plainLinkBuilder = new PlainLinkBuilder();
             var changelog = ChangelogBuilder.CreateForPath(_testDirectory);
-            changelog.Write(new Version(1, 1, 0), new DateTimeOffset(), plainLinkBuilder, new List<ConventionalCommit>
-            {
-                ConventionalCommitParser.Parse(new TestCommit("a360d6a307909c6e571b29d4a329fd786c5d4543", "fix: a fix")),
-                ConventionalCommitParser.Parse(new TestCommit("b360d6a307909c6e571b29d4a329fd786c5d4543", "feat: a feature")),
-                ConventionalCommitParser.Parse(
-                    new TestCommit("c360d6a307909c6e571b29d4a329fd786c5d4543", "feat: a breaking change feature\nBREAKING CHANGE: this will break everything")),
-            });
+            changelog.Write(
+                new Version(1, 1, 0),
+                new DateTimeOffset(),
+                plainLinkBuilder,
+                new List<ConventionalCommit>
+                {
+                    ConventionalCommitParser.Parse(new TestCommit("a360d6a307909c6e571b29d4a329fd786c5d4543", "fix: a fix")),
+                    ConventionalCommitParser.Parse(new TestCommit("b360d6a307909c6e571b29d4a329fd786c5d4543", "feat: a feature")),
+                    ConventionalCommitParser.Parse(
+                        new TestCommit("c360d6a307909c6e571b29d4a329fd786c5d4543", "feat: a breaking change feature\nBREAKING CHANGE: this will break everything")),
+                },
+                ChangelogOptions.Default);
 
             var wasChangelogWritten = File.Exists(Path.Join(_testDirectory, "CHANGELOG.md"));
             Assert.True(wasChangelogWritten);
 
             // TODO: Assert changelog entries
+        }
+
+        [Fact]
+        public void ShouldHideFixSectionWhenHideIsTrue()
+        {
+            var plainLinkBuilder = new PlainLinkBuilder();
+            var changelog = ChangelogBuilder.CreateForPath(_testDirectory);
+            changelog.Write(
+                new Version(1, 1, 0),
+                new DateTimeOffset(),
+                plainLinkBuilder,
+                new List<ConventionalCommit>
+                {
+                    ConventionalCommitParser.Parse(new TestCommit("a360d6a307909c6e571b29d4a329fd786c5d4543", "fix: a fix")),
+                    ConventionalCommitParser.Parse(new TestCommit("b360d6a307909c6e571b29d4a329fd786c5d4543", "feat: a feature")),
+                },
+                ChangelogOptions.Default with
+                {
+                    Sections = new []
+                    {
+                        new ChangelogSection { Type = "feat", Hidden = false, Section = "Features" },
+                        new ChangelogSection { Type = "fix", Hidden = true, Section = "Bug Fixes" },
+                    }
+                });
+
+            var changelogContents = File.ReadAllText(changelog.FilePath);
+            changelogContents.ShouldContain("### Features", Case.Sensitive);
+            changelogContents.ShouldNotContain("Bug Fixes");
+        }
+
+        [Fact]
+        public void ShouldHideFixSectionWhenSectionIsNotSpecified()
+        {
+            var plainLinkBuilder = new PlainLinkBuilder();
+            var changelog = ChangelogBuilder.CreateForPath(_testDirectory);
+            changelog.Write(
+                new Version(1, 1, 0),
+                new DateTimeOffset(),
+                plainLinkBuilder,
+                new List<ConventionalCommit>
+                {
+                    ConventionalCommitParser.Parse(new TestCommit("a360d6a307909c6e571b29d4a329fd786c5d4543", "fix: a fix")),
+                    ConventionalCommitParser.Parse(new TestCommit("b360d6a307909c6e571b29d4a329fd786c5d4543", "feat: a feature")),
+                },
+                ChangelogOptions.Default with
+                {
+                    Sections = new []
+                    {
+                        new ChangelogSection { Type = "feat", Hidden = false, Section = "Features" },
+                    }
+                });
+
+            var changelogContents = File.ReadAllText(changelog.FilePath);
+            changelogContents.ShouldContain("### Features", Case.Sensitive);
+            changelogContents.ShouldNotContain("Bug Fixes");
+        }
+
+        [Fact]
+        public void ShouldShowFixSectionWhenHideIsNotSpecified()
+        {
+            var plainLinkBuilder = new PlainLinkBuilder();
+            var changelog = ChangelogBuilder.CreateForPath(_testDirectory);
+            changelog.Write(
+                new Version(1, 1, 0),
+                new DateTimeOffset(),
+                plainLinkBuilder,
+                new List<ConventionalCommit>
+                {
+                    ConventionalCommitParser.Parse(new TestCommit("a360d6a307909c6e571b29d4a329fd786c5d4543", "fix: a fix")),
+                    ConventionalCommitParser.Parse(new TestCommit("b360d6a307909c6e571b29d4a329fd786c5d4543", "feat: a feature")),
+                },
+                ChangelogOptions.Default with
+                {
+                    Sections = new[]
+                    {
+                        new ChangelogSection { Type = "feat", Hidden = false, Section = "Features" },
+                        new ChangelogSection { Type = "fix", Section = "Bug Fixes" },
+                    }
+                });
+
+            var changelogContents = File.ReadAllText(changelog.FilePath);
+            changelogContents.ShouldContain("### Features", Case.Sensitive);
+            changelogContents.ShouldContain("### Bug Fixes", Case.Sensitive);
+        }
+
+        [Fact]
+        public void ShouldIncludeFixAndFeatCommitsInOtherSectionWhenHiddenAndShowAllIsTrue()
+        {
+            var plainLinkBuilder = new PlainLinkBuilder();
+            var changelog = ChangelogBuilder.CreateForPath(_testDirectory);
+            changelog.Write(
+                new Version(1, 1, 0),
+                new DateTimeOffset(),
+                plainLinkBuilder,
+                new List<ConventionalCommit>
+                {
+                    ConventionalCommitParser.Parse(new TestCommit("a360d6a307909c6e571b29d4a329fd786c5d4543", "fix: a fix")),
+                    ConventionalCommitParser.Parse(new TestCommit("b360d6a307909c6e571b29d4a329fd786c5d4543", "feat: a feature")),
+                },
+                ChangelogOptions.Default with
+                {
+                    IncludeAllCommits = true,
+                    Sections = new[]
+                    {
+                        new ChangelogSection { Type = "feat", Hidden = true, Section = "Features" },
+                        new ChangelogSection { Type = "fix", Hidden = true, Section = "Bug Fixes" },
+                    }
+                });
+
+            var changelogContents = File.ReadAllText(changelog.FilePath);
+            changelogContents.ShouldNotContain("Features");
+            changelogContents.ShouldNotContain("Bug Fixes");
+            changelogContents.ShouldContain("### Other", Case.Sensitive);
+            changelogContents.ShouldContain("a fix");
+            changelogContents.ShouldContain("a feature");
         }
 
         [Fact]
@@ -69,10 +199,15 @@ namespace Versionize.Changelog.Tests
 
             var plainLinkBuilder = new PlainLinkBuilder();
             var changelog = ChangelogBuilder.CreateForPath(_testDirectory);
-            changelog.Write(new Version(1, 0, 0), new DateTimeOffset(), plainLinkBuilder, new List<ConventionalCommit>
-            {
-                ConventionalCommitParser.Parse(new TestCommit("a360d6a307909c6e571b29d4a329fd786c5d4543", "fix: a fix in version 1.0.0")),
-            });
+            changelog.Write(
+                new Version(1, 0, 0),
+                new DateTimeOffset(),
+                plainLinkBuilder,
+                new List<ConventionalCommit>
+                {
+                    ConventionalCommitParser.Parse(new TestCommit("a360d6a307909c6e571b29d4a329fd786c5d4543", "fix: a fix in version 1.0.0")),
+                },
+                ChangelogOptions.Default);
 
             var changelogContents = File.ReadAllText(changelog.FilePath);
             changelogContents.ShouldBe("# Should be kept by versionize\n\nSome information about the changelog\n\n<a name=\"1.0.0\"></a>\n## 1.0.0 (1-1-1)\n\n### Bug Fixes\n\n* a fix in version 1.0.0\n\n");
@@ -83,10 +218,14 @@ namespace Versionize.Changelog.Tests
         {
             var linkBuilder = new GithubLinkBuilder("https://github.com/organization/repository.git");
             var changelog = ChangelogBuilder.CreateForPath(_testDirectory);
-            changelog.Write(new Version(1, 0, 0), new DateTimeOffset(), linkBuilder, new List<ConventionalCommit>
-            {
-                ConventionalCommitParser.Parse(new TestCommit("a360d6a307909c6e571b29d4a329fd786c5d4543", "fix: a fix in version 1.0.0")),
-            });
+            changelog.Write(
+                new Version(1, 0, 0),
+                new DateTimeOffset(),
+                linkBuilder, new List<ConventionalCommit>
+                {
+                    ConventionalCommitParser.Parse(new TestCommit("a360d6a307909c6e571b29d4a329fd786c5d4543", "fix: a fix in version 1.0.0")),
+                },
+                ChangelogOptions.Default);
 
             var changelogContents = File.ReadAllText(changelog.FilePath);
             changelogContents.ShouldContain("* a fix in version 1.0.0 ([a360d6a](https://www.github.com/organization/repository/commit/a360d6a307909c6e571b29d4a329fd786c5d4543))");
@@ -97,10 +236,15 @@ namespace Versionize.Changelog.Tests
         {
             var linkBuilder = new GithubLinkBuilder("git@github.com:organization/repository.git");
             var changelog = ChangelogBuilder.CreateForPath(_testDirectory);
-            changelog.Write(new Version(1, 0, 0), new DateTimeOffset(), linkBuilder, new List<ConventionalCommit>
-            {
-                ConventionalCommitParser.Parse(new TestCommit("a360d6a307909c6e571b29d4a329fd786c5d4543", "fix: a fix in version 1.0.0")),
-            });
+            changelog.Write(
+                new Version(1, 0, 0),
+                new DateTimeOffset(),
+                linkBuilder,
+                new List<ConventionalCommit>
+                {
+                    ConventionalCommitParser.Parse(new TestCommit("a360d6a307909c6e571b29d4a329fd786c5d4543", "fix: a fix in version 1.0.0")),
+                },
+                ChangelogOptions.Default);
 
             var changelogContents = File.ReadAllText(changelog.FilePath);
             changelogContents.ShouldContain("* a fix in version 1.0.0 ([a360d6a](https://www.github.com/organization/repository/commit/a360d6a307909c6e571b29d4a329fd786c5d4543))");
@@ -111,10 +255,15 @@ namespace Versionize.Changelog.Tests
         {
             var linkBuilder = new GithubLinkBuilder("https://github.com/organization/repository.git");
             var changelog = ChangelogBuilder.CreateForPath(_testDirectory);
-            changelog.Write(new Version(1, 0, 0), new DateTimeOffset(), linkBuilder, new List<ConventionalCommit>
-            {
-                ConventionalCommitParser.Parse(new TestCommit("a360d6a307909c6e571b29d4a329fd786c5d4543", "fix: a fix in version 1.0.0")),
-            });
+            changelog.Write(
+                new Version(1, 0, 0),
+                new DateTimeOffset(),
+                linkBuilder,
+                new List<ConventionalCommit>
+                {
+                    ConventionalCommitParser.Parse(new TestCommit("a360d6a307909c6e571b29d4a329fd786c5d4543", "fix: a fix in version 1.0.0")),
+                },
+                ChangelogOptions.Default);
 
             var changelogContents = File.ReadAllText(changelog.FilePath);
             changelogContents.ShouldContain("## [1.0.0](https://www.github.com/organization/repository/releases/tag/v1.0.0)");
@@ -125,10 +274,14 @@ namespace Versionize.Changelog.Tests
         {
             var linkBuilder = new GithubLinkBuilder("git@github.com:organization/repository.git");
             var changelog = ChangelogBuilder.CreateForPath(_testDirectory);
-            changelog.Write(new Version(1, 0, 0), new DateTimeOffset(), linkBuilder, new List<ConventionalCommit>
-            {
-                ConventionalCommitParser.Parse(new TestCommit("a360d6a307909c6e571b29d4a329fd786c5d4543", "fix: a fix in version 1.0.0")),
-            });
+            changelog.Write(
+                new Version(1, 0, 0),
+                new DateTimeOffset(),
+                linkBuilder, new List<ConventionalCommit>
+                {
+                    ConventionalCommitParser.Parse(new TestCommit("a360d6a307909c6e571b29d4a329fd786c5d4543", "fix: a fix in version 1.0.0")),
+                },
+                ChangelogOptions.Default);
 
             var changelogContents = File.ReadAllText(changelog.FilePath);
             changelogContents.ShouldContain("## [1.0.0](https://www.github.com/organization/repository/releases/tag/v1.0.0)");
@@ -139,15 +292,25 @@ namespace Versionize.Changelog.Tests
         {
             var plainLinkBuilder = new PlainLinkBuilder();
             var changelog = ChangelogBuilder.CreateForPath(_testDirectory);
-            changelog.Write(new Version(1, 0, 0), new DateTimeOffset(), plainLinkBuilder, new List<ConventionalCommit>
-            {
-                ConventionalCommitParser.Parse(new TestCommit("a360d6a307909c6e571b29d4a329fd786c5d4543", "fix: a fix in version 1.0.0")),
-            });
+            changelog.Write(
+                new Version(1, 0, 0),
+                new DateTimeOffset(),
+                plainLinkBuilder,
+                new List<ConventionalCommit>
+                {
+                    ConventionalCommitParser.Parse(new TestCommit("a360d6a307909c6e571b29d4a329fd786c5d4543", "fix: a fix in version 1.0.0")),
+                },
+                ChangelogOptions.Default);
 
-            changelog.Write(new Version(1, 1, 0), new DateTimeOffset(), plainLinkBuilder, new List<ConventionalCommit>
-            {
-                ConventionalCommitParser.Parse(new TestCommit("b360d6a307909c6e571b29d4a329fd786c5d4543", "fix: a fix in version 1.1.0")),
-            });
+            changelog.Write(
+                new Version(1, 1, 0),
+                new DateTimeOffset(),
+                plainLinkBuilder,
+                new List<ConventionalCommit>
+                {
+                    ConventionalCommitParser.Parse(new TestCommit("b360d6a307909c6e571b29d4a329fd786c5d4543", "fix: a fix in version 1.1.0")),
+                },
+                ChangelogOptions.Default);
 
             var changelogContents = File.ReadAllText(changelog.FilePath);
 
@@ -171,11 +334,16 @@ namespace Versionize.Changelog.Tests
         {
             var plainLinkBuilder = new PlainLinkBuilder();
             var changelog = ChangelogBuilder.CreateForPath(_testDirectory);
-            changelog.Write(new Version(1, 1, 0), new DateTimeOffset(), plainLinkBuilder, new List<ConventionalCommit>
-            {
-                ConventionalCommitParser.Parse(new TestCommit("a360d6a307909c6e571b29d4a329fd786c5d4543", "chore: nothing important")),
-                ConventionalCommitParser.Parse(new TestCommit("b360d6a307909c6e571b29d4a329fd786c5d4543", "chore: some foo bar")),
-            }, true);
+            changelog.Write(
+                new Version(1, 1, 0),
+                new DateTimeOffset(),
+                plainLinkBuilder,
+                new List<ConventionalCommit>
+                {
+                    ConventionalCommitParser.Parse(new TestCommit("a360d6a307909c6e571b29d4a329fd786c5d4543", "chore: nothing important")),
+                    ConventionalCommitParser.Parse(new TestCommit("b360d6a307909c6e571b29d4a329fd786c5d4543", "chore: some foo bar")),
+                },
+                ChangelogOptions.Default with { IncludeAllCommits = true });
 
             var changelogContents = File.ReadAllText(changelog.FilePath);
 

--- a/Versionize.Tests/Versionize.Tests.csproj
+++ b/Versionize.Tests/Versionize.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Versionize/ChangelogOptions.cs
+++ b/Versionize/ChangelogOptions.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Versionize
+{
+    // TODO: Consider creating a ChangelogConfigurationContract as a layer of abstraction.
+    public record class ChangelogOptions
+    {
+        private const string Preamble = "# Change Log\n\nAll notable changes to this project will be documented in this file. See [versionize](https://github.com/saintedlama/versionize) for commit guidelines.\n";
+        public static readonly ChangelogOptions Default = new ChangelogOptions
+        {
+            Header = Preamble,
+            IncludeAllCommits = false,
+            Sections = new ChangelogSection[]
+            {
+                new ChangelogSection { Type = "feat", Section = "Features", Hidden = false },
+                new ChangelogSection { Type = "fix", Section = "Bug Fixes", Hidden = false },
+            }
+        };
+
+        public string Header { get; set; }
+        // Ignoring this serialization option for the moment, since ConfigurationContract
+        // already has this option. It would be nice to remove that other option in favor
+        // of this one, but it would be a breaking change.
+        [JsonIgnore]
+        public bool IncludeAllCommits { get; set; }
+        public IEnumerable<ChangelogSection> Sections { get; set; }
+    }
+}

--- a/Versionize/ChangelogSection.cs
+++ b/Versionize/ChangelogSection.cs
@@ -1,0 +1,9 @@
+﻿namespace Versionize
+{
+    public class ChangelogSection
+    {
+        public string Type { get; set; }
+        public string Section { get; set; }
+        public bool Hidden { get; set; }
+    }
+}

--- a/Versionize/ConfigurationContract.cs
+++ b/Versionize/ConfigurationContract.cs
@@ -1,5 +1,4 @@
-
-using System;
+﻿using System;
 
 namespace Versionize
 {
@@ -13,5 +12,6 @@ namespace Versionize
         public bool? IgnoreInsignificantCommits { get; set; }
         public bool? ChangelogAll { get; set; }
         public String CommitSuffix { get; set; }
+        public ChangelogOptions Changelog { get; set; }
     }
 }

--- a/Versionize/Program.cs
+++ b/Versionize/Program.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Text.Json;
 using McMaster.Extensions.CommandLineUtils;
@@ -57,9 +57,10 @@ namespace Versionize
                     SkipCommit = optionSkipCommit.HasValue(),
                     ReleaseAs = optionReleaseAs.Value(),
                     IgnoreInsignificantCommits = optionIgnoreInsignificant.HasValue(),
-                    ChangelogAll = optionIncludeAllCommitsInChangelog.HasValue(),
                     CommitSuffix = optionCommitSuffix.Value(),
-                });
+                    Changelog = ChangelogOptions.Default,
+                },
+                optionIncludeAllCommitsInChangelog.HasValue());
 
                 CommandLineUI.Verbosity = MergeBool(optionSilent.HasValue(), jsonFileConfig?.Silent) ? LogLevel.Silent : LogLevel.All;
 
@@ -103,8 +104,14 @@ namespace Versionize
             }
         }
 
-        private static VersionizeOptions MergeWithOptions(ConfigurationContract optionalConfiguration, VersionizeOptions configuration)
+        private static VersionizeOptions MergeWithOptions(
+            ConfigurationContract optionalConfiguration,
+            VersionizeOptions configuration,
+            bool changelogAll)
         {
+            var includeAllCommits = MergeBool(changelogAll, optionalConfiguration?.ChangelogAll);
+            var changelog = MergeChangelogOptions(optionalConfiguration?.Changelog, configuration.Changelog);
+            changelog.IncludeAllCommits = includeAllCommits;
             return new VersionizeOptions
             {
                 DryRun = MergeBool(configuration.DryRun, optionalConfiguration?.DryRun),
@@ -112,8 +119,22 @@ namespace Versionize
                 SkipCommit = MergeBool(configuration.SkipCommit, optionalConfiguration?.SkipCommit),
                 ReleaseAs = configuration.ReleaseAs ?? optionalConfiguration?.ReleaseAs,
                 IgnoreInsignificantCommits = MergeBool(configuration.IgnoreInsignificantCommits, optionalConfiguration?.IgnoreInsignificantCommits),
-                ChangelogAll = MergeBool(configuration.ChangelogAll, optionalConfiguration?.ChangelogAll),
                 CommitSuffix = configuration.CommitSuffix ?? optionalConfiguration?.CommitSuffix,
+                Changelog = changelog,
+            };
+        }
+
+        private static ChangelogOptions MergeChangelogOptions(ChangelogOptions customOptions, ChangelogOptions defaultOptions)
+        {
+            if (customOptions == null)
+            {
+                return defaultOptions;
+            }
+
+            return new ChangelogOptions
+            {
+                Header = customOptions.Header ?? defaultOptions.Header,
+                Sections = customOptions.Sections ?? defaultOptions.Sections,
             };
         }
 

--- a/Versionize/Versionize.csproj
+++ b/Versionize/Versionize.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <Version>1.10.0</Version>
     <ToolCommandName>versionize</ToolCommandName>
+    <LangVersion>latest</LangVersion>
     <PackAsTool>True</PackAsTool>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>

--- a/Versionize/VersionizeOptions.cs
+++ b/Versionize/VersionizeOptions.cs
@@ -1,4 +1,6 @@
-using System;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Versionize
 {
@@ -9,7 +11,7 @@ namespace Versionize
         public bool SkipCommit { get; set; }
         public String ReleaseAs { get; set; }
         public bool IgnoreInsignificantCommits { get; set; }
-        public bool ChangelogAll { get; set; }
         public String CommitSuffix { get; set; }
+        public ChangelogOptions Changelog { get; set; } = ChangelogOptions.Default;
     }
 }

--- a/Versionize/WorkingCopy.cs
+++ b/Versionize/WorkingCopy.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
 using LibGit2Sharp;
@@ -115,7 +115,7 @@ namespace Versionize
                 if (!options.DryRun)
                 {
                     var changelogLinkBuilder = LinkBuilderFactory.CreateFor(repo);
-                    changelog.Write(nextVersion, versionTime, changelogLinkBuilder, conventionalCommits, options.ChangelogAll);
+                    changelog.Write(nextVersion, versionTime, changelogLinkBuilder, conventionalCommits, options.Changelog);
                 }
 
                 Step("updated CHANGELOG.md");


### PR DESCRIPTION
Hello @saintedlama! Love the library.

I thought it would be cool to support customizing the changelog sections and header (via the `.versionize` file) like standard-version does with `.versionrc`. I'd still like to add some more tests and do another code overview, but I figured I'd go ahead and create an "in progress" PR in order to get your thoughts.

So the `.versionize` json would look something like this:

```json
{
  "skipDirty": true,
  "changelog": {
    "header": "My changelog",
    "sections": [
      {
        "type": "feat",
        "section": "Cool Features",
        "hidden": false
      }
    ]
  }
}
```