### PR TITLE
feat: print changelog diff during a dry-run

### DIFF
--- a/Versionize.Tests/Changelog/ChangelogBuilderTests.cs
+++ b/Versionize.Tests/Changelog/ChangelogBuilderTests.cs
@@ -71,10 +71,20 @@ namespace Versionize.Changelog.Tests
                 },
                 ChangelogOptions.Default);
 
-            var wasChangelogWritten = File.Exists(Path.Join(_testDirectory, "CHANGELOG.md"));
-            Assert.True(wasChangelogWritten);
+            var changelogContents = File.ReadAllText(changelog.FilePath);
 
-            // TODO: Assert changelog entries
+            var sb = new ChangelogStringBuilder();
+            sb.Append(ChangelogOptions.Preamble);
+            sb.Append("<a name=\"1.1.0\"></a>");
+            sb.Append("## 1.1.0 (1-1-1)", 2);
+            sb.Append("### Features", 2);
+            sb.Append("* a breaking change feature");
+            sb.Append("* a feature", 2);
+            sb.Append("### Bug Fixes", 2);
+            sb.Append("* a fix", 2);
+            sb.Append("### Breaking Changes", 2);
+            sb.Append("* a breaking change feature", 2);
+            Assert.Equal(sb.Build(), changelogContents);
         }
 
         [Fact]
@@ -371,6 +381,36 @@ namespace Versionize.Changelog.Tests
 
             changelogContents.ShouldContain("nothing important");
             changelogContents.ShouldContain("some foo bar");
+        }
+
+        [Fact]
+        public void GenerateMarkdownShouldGenerateMarkdownForFixFeatAndBreakingCommits()
+        {
+            var plainLinkBuilder = new PlainLinkBuilder();
+            string markdown = ChangelogBuilder.GenerateMarkdown(
+                new Version(1, 1, 0),
+                new DateTimeOffset(),
+                plainLinkBuilder,
+                new List<ConventionalCommit>
+                {
+                    ConventionalCommitParser.Parse(new TestCommit("a360d6a307909c6e571b29d4a329fd786c5d4543", "fix: a fix")),
+                    ConventionalCommitParser.Parse(new TestCommit("b360d6a307909c6e571b29d4a329fd786c5d4543", "feat: a feature")),
+                    ConventionalCommitParser.Parse(
+                        new TestCommit("c360d6a307909c6e571b29d4a329fd786c5d4543", "feat: a breaking change feature\nBREAKING CHANGE: this will break everything")),
+                },
+                ChangelogOptions.Default);
+
+            var sb = new ChangelogStringBuilder();
+            sb.Append("<a name=\"1.1.0\"></a>");
+            sb.Append("## 1.1.0 (1-1-1)", 2);
+            sb.Append("### Features", 2);
+            sb.Append("* a breaking change feature");
+            sb.Append("* a feature", 2);
+            sb.Append("### Bug Fixes", 2);
+            sb.Append("* a fix", 2);
+            sb.Append("### Breaking Changes", 2);
+            sb.Append("* a breaking change feature", 2);
+            Assert.Equal(sb.Build(), markdown);
         }
 
         public void Dispose()

--- a/Versionize.Tests/TestSupport/ChangelogStringBuilder.cs
+++ b/Versionize.Tests/TestSupport/ChangelogStringBuilder.cs
@@ -1,0 +1,21 @@
+﻿using System.Text;
+
+namespace Versionize.Tests.TestSupport
+{
+    public class ChangelogStringBuilder
+    {
+        private readonly StringBuilder _sb = new();
+
+        public ChangelogStringBuilder Append(string text, int lineBreaks = 1)
+        {
+            _sb.Append(text);
+            for (int i = 0; i < lineBreaks; i++)
+            {
+                _sb.Append('\n');
+            }
+            return this;
+        }
+
+        public string Build() => _sb.ToString();
+    }
+}

--- a/Versionize.Tests/WorkingCopyTests.cs
+++ b/Versionize.Tests/WorkingCopyTests.cs
@@ -49,21 +49,23 @@ namespace Versionize.Tests
         }
 
         [Fact]
-        public void ShouldPreformADryRun()
+        public void ShouldPerformADryRun()
         {
             TempCsProject.Create(_testSetup.WorkingDirectory);
 
             File.WriteAllText(Path.Join(_testSetup.WorkingDirectory, "hello.txt"), "First commit");
-            CommitAll(_testSetup.Repository);
-
-            File.WriteAllText(Path.Join(_testSetup.WorkingDirectory, "hello.txt"), "Second commit");
-            CommitAll(_testSetup.Repository);
+            CommitAll(_testSetup.Repository, "feat: first commit");
 
             var workingCopy = WorkingCopy.Discover(_testSetup.WorkingDirectory);
             workingCopy.Versionize(new VersionizeOptions { DryRun = true, SkipDirty = true });
 
-            _testPlatformAbstractions.Messages.Count.ShouldBe(4);
+            _testPlatformAbstractions.Messages.Count.ShouldBe(7);
             _testPlatformAbstractions.Messages[0].Message.ShouldBe("Discovered 1 versionable projects");
+            _testPlatformAbstractions.Messages[3].Message.ShouldBe("\n---");
+            _testPlatformAbstractions.Messages[4].Message.ShouldContain("* first commit");
+            _testPlatformAbstractions.Messages[5].Message.ShouldBe("---\n");
+            var wasChangelogWritten = File.Exists(Path.Join(_testSetup.WorkingDirectory, "CHANGELOG.md"));
+            Assert.False(wasChangelogWritten);
         }
 
         [Fact]

--- a/Versionize/Changelog/ChangelogBuilder.cs
+++ b/Versionize/Changelog/ChangelogBuilder.cs
@@ -23,6 +23,38 @@ namespace Versionize.Changelog
             IEnumerable<ConventionalCommit> commits,
             ChangelogOptions changelogOptions)
         {
+            string markdown = GenerateMarkdown(version, versionTime, linkBuilder, commits, changelogOptions);
+
+            if (File.Exists(FilePath))
+            {
+                var contents = File.ReadAllText(FilePath);
+
+                var firstReleaseHeadlineIdx = contents.IndexOf("<a name=\"", StringComparison.Ordinal);
+
+                if (firstReleaseHeadlineIdx >= 0)
+                {
+                    markdown = contents.Insert(firstReleaseHeadlineIdx, markdown);
+                }
+                else
+                {
+                    markdown = contents + "\n\n" + markdown;
+                }
+
+                File.WriteAllText(FilePath, markdown);
+            }
+            else
+            {
+                File.WriteAllText(FilePath, changelogOptions.Header + "\n" + markdown);
+            }
+        }
+
+        public static string GenerateMarkdown(
+            Version version,
+            DateTimeOffset versionTime,
+            IChangelogLinkBuilder linkBuilder,
+            IEnumerable<ConventionalCommit> commits,
+            ChangelogOptions changelogOptions)
+        {
             var versionTagLink = string.IsNullOrWhiteSpace(linkBuilder.BuildVersionTagLink(version))
                 ? version.ToString()
                 : $"[{version}]({linkBuilder.BuildVersionTagLink(version)})";
@@ -68,27 +100,7 @@ namespace Versionize.Changelog
                 }
             }
 
-            if (File.Exists(FilePath))
-            {
-                var contents = File.ReadAllText(FilePath);
-
-                var firstReleaseHeadlineIdx = contents.IndexOf("<a name=\"", StringComparison.Ordinal);
-
-                if (firstReleaseHeadlineIdx >= 0)
-                {
-                    markdown = contents.Insert(firstReleaseHeadlineIdx, markdown);
-                }
-                else
-                {
-                    markdown = contents + "\n\n" + markdown;
-                }
-
-                File.WriteAllText(FilePath, markdown);
-            }
-            else
-            {
-                File.WriteAllText(FilePath, changelogOptions.Header + "\n" + markdown);
-            }
+            return markdown;
         }
 
         public static string BuildBlock(string header, IChangelogLinkBuilder linkBuilder, IEnumerable<ConventionalCommit> commits)

--- a/Versionize/ChangelogOptions.cs
+++ b/Versionize/ChangelogOptions.cs
@@ -6,7 +6,7 @@ namespace Versionize
     // TODO: Consider creating a ChangelogConfigurationContract as a layer of abstraction.
     public record class ChangelogOptions
     {
-        private const string Preamble = "# Change Log\n\nAll notable changes to this project will be documented in this file. See [versionize](https://github.com/saintedlama/versionize) for commit guidelines.\n";
+        public const string Preamble = "# Change Log\n\nAll notable changes to this project will be documented in this file. See [versionize](https://github.com/saintedlama/versionize) for commit guidelines.\n";
         public static readonly ChangelogOptions Default = new ChangelogOptions
         {
             Header = Preamble,

--- a/Versionize/WorkingCopy.cs
+++ b/Versionize/WorkingCopy.cs
@@ -111,10 +111,17 @@ namespace Versionize
                 Step($"bumping version from {projects.Version} to {nextVersion} in projects");
 
                 var changelog = ChangelogBuilder.CreateForPath(workingDirectory);
+                var changelogLinkBuilder = LinkBuilderFactory.CreateFor(repo);
 
-                if (!options.DryRun)
+                if (options.DryRun)
                 {
-                    var changelogLinkBuilder = LinkBuilderFactory.CreateFor(repo);
+                    string markdown = ChangelogBuilder.GenerateMarkdown(nextVersion, versionTime, changelogLinkBuilder, conventionalCommits, options.Changelog);
+                    Information("\n---");
+                    Information(markdown.TrimEnd('\n'));
+                    Information("---\n");
+                }
+                else
+                {
                     changelog.Write(nextVersion, versionTime, changelogLinkBuilder, conventionalCommits, options.Changelog);
                 }
 


### PR DESCRIPTION
Output looks like the following:

![versionize-changelog-dryrun](https://user-images.githubusercontent.com/6819362/151813069-476f61e1-825c-42b2-bcd6-c874eb8acd5b.jpg)

_Side note: Not sure what's wrong with the coloring on my machine._